### PR TITLE
Add markdown linting to CI workflow

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,0 +1,13 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^#"
+    }
+  ],
+  "replacementPatterns": [],
+  "httpHeaders": [],
+  "timeout": "10s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "5s"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,18 @@ jobs:
 
       - name: Run staticcheck
         run: staticcheck ./...
+
+  markdown:
+    name: Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check markdown formatting
+        uses: DavidAnson/markdownlint-cli2-action@v18
+
+      - name: Check markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          config-file: '.github/markdown-link-check.json'

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,15 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD022": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD031": false,
+  "MD032": false,
+  "MD033": false,
+  "MD036": false,
+  "MD040": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -127,4 +127,4 @@ The performance stats in DESIGN.md and docs/MATCHING.md are measured using this 
 ## License
 
 Big Buck Bunny is licensed under Creative Commons Attribution 3.0.
-See: https://peach.blender.org/
+See: <https://peach.blender.org/>


### PR DESCRIPTION
## Summary
- Add markdown linting job to CI workflow using `markdownlint-cli2-action`
- Add link checking using `github-action-markdown-link-check`
- Add configuration files for both tools

## Configuration
The `.markdownlint.json` config disables several rules to accommodate existing documentation style:
- MD013 (line length) - many docs have long lines
- MD022, MD031, MD032 (blank line requirements) - existing style doesn't always use them
- MD033 (inline HTML) - sometimes needed
- MD036 (emphasis as heading) - intentional styling choice
- MD040 (fenced code language) - some generic examples
- MD041 (first line heading) - not all docs start with H1
- MD060 (table style) - existing tables use various styles

## Test plan
- [x] Run `npx markdownlint-cli2 "**/*.md"` locally - passes with 0 errors
- [x] CI workflow runs successfully on PR

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)