### PR TITLE
Add CLI tests, integration tests, and gotestsum CI (Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install -y libfuse-dev
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.12.0
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install -y libfuse-dev
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.12.0
 
       - name: Run tests with coverage
         run: gotestsum --junitfile test-results.xml --jsonfile test-results.json -- -coverprofile=coverage.out -covermode=atomic ./...

--- a/cmd/mkvdup/commands_test.go
+++ b/cmd/mkvdup/commands_test.go
@@ -193,7 +193,10 @@ func TestCalculateFileChecksum(t *testing.T) {
 	})
 
 	t.Run("file not found", func(t *testing.T) {
-		_, err := calculateFileChecksum("/nonexistent/path/file.bin")
+		tmpDir := t.TempDir()
+		missingFile := filepath.Join(tmpDir, "nonexistent.bin")
+
+		_, err := calculateFileChecksum(missingFile)
 		if err == nil {
 			t.Error("Expected error for nonexistent file")
 		}


### PR DESCRIPTION
## Summary
- Add CLI package tests for `samplePackets`, `calculateFileChecksum`, and `ProbeResult` struct
- Expand integration tests with concurrent reader tests and integrity verification
- Enhance CI with gotestsum for better test output and JUnit XML reports
- Publish test results to gh-pages alongside coverage data

## Test plan
- [x] CLI tests pass locally (`go test ./cmd/mkvdup/...`)
- [x] Integration tests pass locally (requires test data)
- [x] Full test suite passes
- [ ] CI workflows run successfully with gotestsum

## Coverage changes
| Package | Before | After | Change |
|---------|--------|-------|--------|
| cmd/mkvdup | 0% | 5.3% | +5.3% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)