### PR TITLE
Add canary/test release channel with separate package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
       commit: ${{ steps.resolve.outputs.commit }}
       tag: ${{ steps.resolve.outputs.tag }}
+      is_canary: ${{ steps.resolve.outputs.is_canary }}
+      package_name: ${{ steps.resolve.outputs.package_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -42,6 +44,16 @@ jobs:
           TAG="v${VERSION}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+          # Detect canary release
+          IS_CANARY=false
+          PACKAGE_NAME="mkvdup"
+          if [[ "$VERSION" == *-canary.* ]]; then
+            IS_CANARY=true
+            PACKAGE_NAME="mkvdup-canary"
+          fi
+          echo "is_canary=${IS_CANARY}" >> $GITHUB_OUTPUT
+          echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
 
           # Check if tag already exists
           if git rev-parse "${TAG}" >/dev/null 2>&1; then
@@ -104,7 +116,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
         run: |
-          go build -ldflags="-s -w -X main.version=${{ needs.prepare.outputs.version }}" -o mkvdup ./cmd/mkvdup
+          go build -ldflags="-s -w -X main.version=${{ needs.prepare.outputs.version }}" -o ${{ needs.prepare.outputs.package_name }} ./cmd/mkvdup
 
       - name: Install nfpm
         run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
@@ -113,6 +125,7 @@ jobs:
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           GOARCH: ${{ matrix.goarch }}
+          PACKAGE_NAME: ${{ needs.prepare.outputs.package_name }}
         run: |
           nfpm package --packager deb --target .
 
@@ -120,6 +133,7 @@ jobs:
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           GOARCH: ${{ matrix.goarch }}
+          PACKAGE_NAME: ${{ needs.prepare.outputs.package_name }}
         run: |
           nfpm package --packager rpm --target .
 
@@ -157,6 +171,7 @@ jobs:
           tag_name: ${{ needs.prepare.outputs.tag }}
           files: packages/*
           generate_release_notes: true
+          prerelease: ${{ needs.prepare.outputs.is_canary == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -214,34 +229,51 @@ jobs:
           merge-multiple: true
 
       - name: Setup APT repository structure
+        env:
+          IS_CANARY: ${{ needs.prepare.outputs.is_canary }}
         run: |
           cd gh-pages
 
+          # Set paths based on release channel
+          if [[ "$IS_CANARY" == "true" ]]; then
+            POOL="pool/canary"
+            DIST="dists/canary"
+            SUITE="canary"
+            LABEL="mkvdup-canary"
+            DESC="mkvdup canary packages"
+          else
+            POOL="pool/main"
+            DIST="dists/stable"
+            SUITE="stable"
+            LABEL="mkvdup"
+            DESC="mkvdup packages"
+          fi
+
           # Create directory structure
-          mkdir -p apt/pool/main
-          mkdir -p apt/dists/stable/main/binary-amd64
-          mkdir -p apt/dists/stable/main/binary-arm64
+          mkdir -p "apt/${POOL}"
+          mkdir -p "apt/${DIST}/main/binary-amd64"
+          mkdir -p "apt/${DIST}/main/binary-arm64"
 
           # Copy deb packages to pool
-          cp ../packages/*.deb apt/pool/main/
+          cp ../packages/*.deb "apt/${POOL}/"
 
           # Generate Packages files for each architecture
           cd apt
-          dpkg-scanpackages --arch amd64 pool/ > dists/stable/main/binary-amd64/Packages
-          gzip -k -f dists/stable/main/binary-amd64/Packages
-          dpkg-scanpackages --arch arm64 pool/ > dists/stable/main/binary-arm64/Packages
-          gzip -k -f dists/stable/main/binary-arm64/Packages
+          dpkg-scanpackages --arch amd64 "${POOL}/" > "${DIST}/main/binary-amd64/Packages"
+          gzip -k -f "${DIST}/main/binary-amd64/Packages"
+          dpkg-scanpackages --arch arm64 "${POOL}/" > "${DIST}/main/binary-arm64/Packages"
+          gzip -k -f "${DIST}/main/binary-arm64/Packages"
 
           # Create Release file
-          cd dists/stable
+          cd "${DIST}"
           cat > Release << EOF
-          Origin: mkvdup
-          Label: mkvdup
-          Suite: stable
-          Codename: stable
+          Origin: ${LABEL}
+          Label: ${LABEL}
+          Suite: ${SUITE}
+          Codename: ${SUITE}
           Architectures: amd64 arm64
           Components: main
-          Description: mkvdup packages
+          Description: ${DESC}
           Date: $(date -Ru)
           EOF
 
@@ -261,17 +293,26 @@ jobs:
           echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --armor --passphrase-fd 0 --clearsign -o InRelease Release
 
       - name: Setup YUM repository structure
+        env:
+          IS_CANARY: ${{ needs.prepare.outputs.is_canary }}
         run: |
           cd gh-pages
 
+          # Set YUM directory based on release channel
+          if [[ "$IS_CANARY" == "true" ]]; then
+            YUM_DIR="yum-canary"
+          else
+            YUM_DIR="yum"
+          fi
+
           # Create directory structure
-          mkdir -p yum/packages
+          mkdir -p "${YUM_DIR}/packages"
 
           # Copy rpm packages
-          cp ../packages/*.rpm yum/packages/
+          cp ../packages/*.rpm "${YUM_DIR}/packages/"
 
           # Generate repository metadata
-          cd yum
+          cd "${YUM_DIR}"
           createrepo_c .
 
           # Sign the repository metadata
@@ -281,8 +322,10 @@ jobs:
         run: |
           cd gh-pages
           gpg --armor --export ${{ env.GPG_KEY_ID }} > gpg-key.asc
-          cp gpg-key.asc apt/
-          cp gpg-key.asc yum/
+          # Copy to all repo directories that exist
+          for dir in apt yum yum-canary; do
+            [[ -d "$dir" ]] && cp gpg-key.asc "$dir/"
+          done
 
       - name: Create index page
         run: |
@@ -329,6 +372,37 @@ jobs:
 
           # Install
           sudo dnf install mkvdup</pre>
+
+            <h2>Canary Channel (Pre-release)</h2>
+            <p>The canary channel provides early access to new features. It installs as
+            <code>mkvdup-canary</code> and can be installed alongside the stable version.</p>
+
+            <h3>Debian/Ubuntu (APT) - Canary</h3>
+            <pre>
+          # Add the GPG key (same key as stable)
+          curl -fsSL https://stuckj.github.io/mkvdup/gpg-key.asc | sudo gpg --dearmor -o /usr/share/keyrings/mkvdup.gpg
+
+          # Add the canary repository
+          echo "deb [signed-by=/usr/share/keyrings/mkvdup.gpg arch=amd64,arm64] https://stuckj.github.io/mkvdup/apt canary main" | sudo tee /etc/apt/sources.list.d/mkvdup-canary.list
+
+          # Install
+          sudo apt update
+          sudo apt install mkvdup-canary</pre>
+
+            <h3>RHEL/CentOS/Fedora (YUM/DNF) - Canary</h3>
+            <pre>
+          # Add the canary repository
+          sudo tee /etc/yum.repos.d/mkvdup-canary.repo &lt;&lt; 'REPO'
+          [mkvdup-canary]
+          name=mkvdup-canary
+          baseurl=https://stuckj.github.io/mkvdup/yum-canary
+          enabled=1
+          gpgcheck=1
+          gpgkey=https://stuckj.github.io/mkvdup/yum-canary/gpg-key.asc
+          REPO
+
+          # Install
+          sudo dnf install mkvdup-canary</pre>
 
             <h2>Links</h2>
             <ul>

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 /mkvdup
+/mkvdup-canary
 *.exe
 *.exe~
 *.dll

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,6 +77,66 @@ Follow semantic versioning (semver):
 - MINOR: New features, backwards compatible
 - PATCH: Bug fixes, backwards compatible
 
+## Canary Releases
+
+Canary releases provide early access to new features and are installed as a
+separate `mkvdup-canary` package that coexists with the stable `mkvdup`.
+
+### Canary Version Format
+
+Use the format `MAJOR.MINOR.PATCH-canary.N` where N is an incrementing number:
+- `1.2.0-canary.1`
+- `1.2.0-canary.2`
+
+### Creating a Canary Release
+
+Use the same workflow dispatch as stable releases, but with a canary version:
+
+1. Go to Actions > "Build and Release Packages"
+2. Click "Run workflow"
+3. Enter the version (e.g., `1.2.0-canary.1`)
+4. Click "Run workflow"
+
+The workflow automatically detects the `-canary.` suffix and:
+- Builds the binary as `mkvdup-canary`
+- Packages as `mkvdup-canary` (installs to `/usr/bin/mkvdup-canary`)
+- Creates a pre-release on GitHub
+- Publishes to the canary APT/YUM repositories (separate from stable)
+
+### Canary Package Repositories
+
+#### APT (Debian/Ubuntu) - Canary
+
+```bash
+curl -fsSL https://stuckj.github.io/mkvdup/gpg-key.asc | sudo gpg --dearmor -o /usr/share/keyrings/mkvdup.gpg
+echo "deb [signed-by=/usr/share/keyrings/mkvdup.gpg arch=amd64,arm64] https://stuckj.github.io/mkvdup/apt canary main" | sudo tee /etc/apt/sources.list.d/mkvdup-canary.list
+sudo apt update
+sudo apt install mkvdup-canary
+```
+
+#### YUM/DNF (RHEL/Fedora) - Canary
+
+```bash
+sudo tee /etc/yum.repos.d/mkvdup-canary.repo << 'EOF'
+[mkvdup-canary]
+name=mkvdup-canary
+baseurl=https://stuckj.github.io/mkvdup/yum-canary
+enabled=1
+gpgcheck=1
+gpgkey=https://stuckj.github.io/mkvdup/yum-canary/gpg-key.asc
+EOF
+
+sudo dnf install mkvdup-canary
+```
+
+### Local Testing (Canary)
+
+```bash
+go build -o mkvdup-canary ./cmd/mkvdup
+PACKAGE_NAME=mkvdup-canary VERSION=1.0.0-canary.1 GOARCH=amd64 nfpm package --packager deb
+PACKAGE_NAME=mkvdup-canary VERSION=1.0.0-canary.1 GOARCH=amd64 nfpm package --packager rpm
+```
+
 ## What Gets Built
 
 Each release produces:
@@ -148,6 +208,6 @@ go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
 go build -o mkvdup ./cmd/mkvdup
 
 # Build packages
-VERSION=1.0.0 GOARCH=amd64 nfpm package --packager deb
-VERSION=1.0.0 GOARCH=amd64 nfpm package --packager rpm
+PACKAGE_NAME=mkvdup VERSION=1.0.0 GOARCH=amd64 nfpm package --packager deb
+PACKAGE_NAME=mkvdup VERSION=1.0.0 GOARCH=amd64 nfpm package --packager rpm
 ```

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,7 +1,10 @@
 # nfpm configuration for building deb and rpm packages
 # See: https://nfpm.goreleaser.com/configuration/
+#
+# Set PACKAGE_NAME env var to control the package name:
+#   PACKAGE_NAME=mkvdup (stable) or PACKAGE_NAME=mkvdup-canary (canary)
 
-name: mkvdup
+name: "${PACKAGE_NAME}"
 arch: "${GOARCH}"
 platform: linux
 version: "${VERSION}"
@@ -23,47 +26,55 @@ depends:
 # Files to include in the package
 contents:
   # Binary
-  - src: mkvdup
-    dst: /usr/bin/mkvdup
+  - src: "${PACKAGE_NAME}"
+    dst: /usr/bin/${PACKAGE_NAME}
+    expand: true
     file_info:
       mode: 0755
 
   # Documentation
   - src: README.md
-    dst: /usr/share/doc/mkvdup/README.md
+    dst: /usr/share/doc/${PACKAGE_NAME}/README.md
+    expand: true
     file_info:
       mode: 0644
 
   - src: DESIGN.md
-    dst: /usr/share/doc/mkvdup/DESIGN.md
+    dst: /usr/share/doc/${PACKAGE_NAME}/DESIGN.md
+    expand: true
     file_info:
       mode: 0644
 
   - src: LICENSE
-    dst: /usr/share/doc/mkvdup/LICENSE
+    dst: /usr/share/doc/${PACKAGE_NAME}/LICENSE
+    expand: true
     file_info:
       mode: 0644
 
   - src: docs/
-    dst: /usr/share/doc/mkvdup/docs/
+    dst: /usr/share/doc/${PACKAGE_NAME}/docs/
+    expand: true
     file_info:
       mode: 0644
 
   # Man page
   - src: docs/mkvdup.1
-    dst: /usr/share/man/man1/mkvdup.1
+    dst: /usr/share/man/man1/${PACKAGE_NAME}.1
+    expand: true
     file_info:
       mode: 0644
 
-  # Mount helper for fstab/systemd integration (fuse.mkvdup type)
+  # Mount helper for fstab/systemd integration (fuse.${PACKAGE_NAME} type)
   - src: scripts/mount.fuse.mkvdup
-    dst: /usr/sbin/mount.fuse.mkvdup
+    dst: /usr/sbin/mount.fuse.${PACKAGE_NAME}
+    expand: true
     file_info:
       mode: 0755
 
   # Bash completion
   - src: scripts/mkvdup-completion.bash
-    dst: /usr/share/bash-completion/completions/mkvdup
+    dst: /usr/share/bash-completion/completions/${PACKAGE_NAME}
+    expand: true
     file_info:
       mode: 0644
 

--- a/scripts/mkvdup-completion.bash
+++ b/scripts/mkvdup-completion.bash
@@ -190,4 +190,6 @@ _mkvdup() {
     esac
 }
 
-complete -F _mkvdup mkvdup
+# Register completion for the command matching this file's installed name.
+# Works for both 'mkvdup' and 'mkvdup-canary' using the same source file.
+complete -F _mkvdup "${BASH_SOURCE[0]##*/}"

--- a/scripts/mount.fuse.mkvdup
+++ b/scripts/mount.fuse.mkvdup
@@ -115,10 +115,15 @@ if [[ "$CONFIG_DIR" == "true" ]]; then
     MKVDUP_ARGS+=("--config-dir")
 fi
 
+# Derive binary name from script name (e.g., mount.fuse.mkvdup -> mkvdup,
+# mount.fuse.mkvdup-canary -> mkvdup-canary)
+SCRIPT_NAME="$(basename "$0")"
+MKVDUP_BIN="/usr/bin/${SCRIPT_NAME#mount.fuse.}"
+
 # Build the command
 # If WHAT is "none" or empty, use default config
 if [[ "$WHAT" == "none" || -z "$WHAT" ]]; then
-    exec /usr/bin/mkvdup mount "${MKVDUP_ARGS[@]}" "$WHERE"
+    exec "$MKVDUP_BIN" mount "${MKVDUP_ARGS[@]}" "$WHERE"
 else
-    exec /usr/bin/mkvdup mount "${MKVDUP_ARGS[@]}" "$WHERE" "$WHAT"
+    exec "$MKVDUP_BIN" mount "${MKVDUP_ARGS[@]}" "$WHERE" "$WHAT"
 fi


### PR DESCRIPTION
## Summary

- Adds a canary release channel using Option 1 from #65 (separate package name)
- Versions with a `-canary.N` suffix (e.g., `1.2.0-canary.1`) build as `mkvdup-canary`, installable side-by-side with stable `mkvdup`
- DRY approach: 0 new files, 5 modified files -- existing scripts are made name-aware and reused via env vars

## Changes

- **`nfpm.yaml`**: Parameterized with `${PACKAGE_NAME}` env var + `expand: true` so a single config produces both stable and canary packages
- **`scripts/mount.fuse.mkvdup`**: Derives binary path from `$0`, so the same file works installed as `mount.fuse.mkvdup` or `mount.fuse.mkvdup-canary`
- **`scripts/mkvdup-completion.bash`**: Registers completion for command name from `${BASH_SOURCE[0]}`, reusable for both packages
- **`.github/workflows/release.yml`**: Canary detection, conditional build/publish paths, prerelease flag, canary install instructions in index.html
- **`RELEASING.md`**: Documents canary release workflow and repo setup
- **`.gitignore`**: Adds `/mkvdup-canary`

## Test plan

- [x] Build stable deb: `PACKAGE_NAME=mkvdup VERSION=1.0.0 GOARCH=amd64 nfpm package --packager deb` -- verified correct paths
- [x] Build canary deb: `PACKAGE_NAME=mkvdup-canary VERSION=1.0.0-canary.1 GOARCH=amd64 nfpm package --packager deb` -- verified all paths use `mkvdup-canary`
- [x] Inspected both .deb contents with `dpkg-deb -c` -- no path overlap, both can coexist
- [x] Verified mount helper name derivation logic
- [ ] Trigger a canary workflow dispatch after merge to validate end-to-end

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)